### PR TITLE
get_certinfo() proto check fix

### DIFF
--- a/class-certificate.php
+++ b/class-certificate.php
@@ -190,7 +190,7 @@ if ( ! class_exists( 'rsssl_certificate' ) ) {
 	        if ($certinfo === 'no-response') return false;
 
 	        if (!$certinfo || RSSSL()->really_simple_ssl->is_settings_page()) {
-                $url = 'https://'.$url;
+                if(strpos($url, 'https://') !== 0) $url = 'https://'.$url;
                 $original_parse = parse_url($url, PHP_URL_HOST);
                 if ($original_parse) {
                     $get = stream_context_create(array("ssl" => array("capture_peer_cert" => TRUE)));

--- a/class-certificate.php
+++ b/class-certificate.php
@@ -190,7 +190,12 @@ if ( ! class_exists( 'rsssl_certificate' ) ) {
 	        if ($certinfo === 'no-response') return false;
 
 	        if (!$certinfo || RSSSL()->really_simple_ssl->is_settings_page()) {
-                if(strpos($url, 'https://') !== 0) $url = 'https://'.$url;
+
+	            $url = str_replace('https://', '', $url);
+                $url = str_replace('http://', '', $url);
+
+                $url = 'https://'.$url;
+
                 $original_parse = parse_url($url, PHP_URL_HOST);
                 if ($original_parse) {
                     $get = stream_context_create(array("ssl" => array("capture_peer_cert" => TRUE)));

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.6
 License: GPL2
 Tested up to: 5.6
 Requires PHP: 5.6
-Stable tag: 4.0.7
+Stable tag: 4.0.8
 
 No setup required! You only need an SSL certificate, and this plugin will do the rest.
 
@@ -82,6 +82,9 @@ If you are experiencing redirect loops on your site, try these [instructions](ht
 Yes. There is a dedicated network settings page where you can switch between network activated SSL and per page SSL. In the dedicated pro for multisite plugin, you can override all site settings for SSL on the network level, and can activate and deactivate SSL in the network menu for each site.
 
 == Changelog ==
+= 4.0.8 =
+* Fix: fixed a bug in the get_certinfo() function where an URL with a double prefix could be checked
+
 = 4.0.7 =
 * Fix: catch not set certificate info in case of empty array when no certificate is available
 * Fix: minor CSS fixes

--- a/rlrsssl-really-simple-ssl.php
+++ b/rlrsssl-really-simple-ssl.php
@@ -3,7 +3,7 @@
  * Plugin Name: Really Simple SSL
  * Plugin URI: https://really-simple-ssl.com
  * Description: Lightweight plugin without any setup to make your site SSL proof
- * Version: 4.0.7
+ * Version: 4.0.8
  * Author: Really Simple Plugins
  * Author URI: https://really-simple-plugins.com
  * License: GPL2


### PR DESCRIPTION
This fix checks if the incoming $url already has "https://", which happens in is_wildcard() (network_site_url() returns a url with the protocol), otherwise, parse_url() would return "https" as the hostname. I came across this issue when debugging why my multi-site was loading really slow when loading the network_admin_notices (checking for wildcard certs).