### PR TITLE
add redirect source to wp_redirect_to_ssl

### DIFF
--- a/class-front-end.php
+++ b/class-front-end.php
@@ -84,7 +84,7 @@ if ( ! class_exists( 'rsssl_front_end' ) ) {
 			if ( ! is_ssl() && ! ( defined( 'rsssl_no_wp_redirect' ) && rsssl_no_wp_redirect ) ) {
 				$redirect_url = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 				$redirect_url = apply_filters( 'rsssl_wp_redirect_url', $redirect_url );
-				wp_redirect( $redirect_url, 301 );
+				wp_redirect( $redirect_url, 301, 'WordPress - Really Simple SSL' );
 				exit;
 			}
 		}


### PR DESCRIPTION
fixes #609 

Adds additional info to the redirect, making it easier to debug.